### PR TITLE
[UPD] Field alias via API calling.

### DIFF
--- a/spp_api/__manifest__.py
+++ b/spp_api/__manifest__.py
@@ -25,6 +25,7 @@
         "views/openapi_template.xml",
         "views/res_users_view.xml",
         "views/ir_model_view.xml",
+        "views/spp_api_field_alias_views.xml",
     ],
     "demo": ["demo/openapi_demo.xml", "demo/openapi_security_demo.xml"],
     "post_load": "post_load",

--- a/spp_api/controllers/api.py
+++ b/spp_api/controllers/api.py
@@ -200,7 +200,7 @@ class ApiV1Controller(http.Controller):
         kw = path.search_treatment_kwargs(kw)
         records = self.get_records(path.model, kw)
         records = records.search_read(**kw)
-
+        records = path._get_response_treatment(records)
         response_data = {
             "results": records,
             "total": len(records),
@@ -225,7 +225,7 @@ class ApiV1Controller(http.Controller):
         path.read_treatment_kwargs(kw)
         obj = self.get_record(path.model, id, path, kw)
         result = obj.search_read(domain=[("id", "=", obj.id)], fields=kw["fields"])
-
+        result = path._get_response_treatment(result)
         response_data = result and result[0] or {}
         response_data.update(
             {

--- a/spp_api/models/__init__.py
+++ b/spp_api/models/__init__.py
@@ -1,8 +1,10 @@
 # License LGPL-3.0 or later (https://www.gnu.org/licenses/lgpl.html).
 from . import spp_api_log
 from . import spp_api_namespace
+from . import ir_model_fields
 from . import ir_model
 from . import spp_api_path
+from . import spp_api_field_alias
 from . import spp_api_fields
 from . import spp_api_function_parameter
 from . import res_users

--- a/spp_api/models/ir_model_fields.py
+++ b/spp_api/models/ir_model_fields.py
@@ -1,0 +1,32 @@
+from odoo import _, api, models
+from odoo.exceptions import ValidationError
+
+
+class IrModelFields(models.Model):
+    _inherit = "ir.model.fields"
+
+    @api.depends_context("default_api_path_id")
+    def create_api_field_name_alias(self):
+        self.ensure_one()
+        api_path_id = self._context.get("default_api_path_id")
+        if not api_path_id:
+            raise ValidationError(_("API path is not specify!"))
+        field_alias_sudo = self.env["spp_api.field.alias"].sudo()
+        res = {
+            "type": "ir.actions.act_window",
+            "name": _("Field Name Alias"),
+            "res_model": field_alias_sudo._name,
+            "view_mode": "form",
+            "target": "new",
+            "context": dict(self._context, scoped_alias=True, default_field_id=self.id),
+        }
+        defined_field_alias = field_alias_sudo.search(
+            [
+                ("field_id", "=", self.id),
+                ("api_path_id", "=", api_path_id),
+            ],
+            limit=1,
+        )
+        if defined_field_alias:
+            res["res_id"] = defined_field_alias.id
+        return res

--- a/spp_api/models/spp_api_field_alias.py
+++ b/spp_api/models/spp_api_field_alias.py
@@ -13,6 +13,12 @@ class SppApiFieldAlias(models.Model):
         required=True,
         ondelete="cascade",
     )
+    model_id = fields.Many2one(
+        comodel_name="ir.model",
+        string="Model",
+        related="field_id.model_id",
+        store=True,
+    )
     api_path_id = fields.Many2one(
         comodel_name="spp_api.path",
         string="API Path",

--- a/spp_api/models/spp_api_field_alias.py
+++ b/spp_api/models/spp_api_field_alias.py
@@ -1,0 +1,80 @@
+from odoo import _, api, fields, models
+from odoo.exceptions import ValidationError
+
+
+class SppApiFieldAlias(models.Model):
+    _name = "spp_api.field.alias"
+    _description = "Field Name Alias"
+    _order = "api_path_id DESC, field_id, alias_name"
+
+    field_id = fields.Many2one(
+        comodel_name="ir.model.fields",
+        string="Field",
+        required=True,
+        ondelete="cascade",
+    )
+    api_path_id = fields.Many2one(
+        comodel_name="spp_api.path",
+        string="API Path",
+        ondelete="cascade",
+    )
+    # NOTE: 63 - PostgreSQL constraint name size capacity, no other special meaning
+    alias_name = fields.Char(
+        required=True,
+        size=63,
+    )
+    global_alias = fields.Boolean(inverse="_inverse_global_alias")
+
+    _sql_constraints = [
+        (
+            "field_api_path_uniq",
+            "UNIQUE(field_id, api_path_id)",
+            "Field only alias once in one API Path!",
+        ),
+        (
+            "alias_name_api_path_uniq",
+            "UNIQUE(alias_name, api_path_id)",
+            "Alias name only exists once in one API Path!",
+        ),
+    ]
+
+    def name_get(self):
+        res = []
+        for rec in self:
+            res.append((rec.id, f"{rec.alias_name} - {rec.field_id.name}"))
+        return res
+
+    @api.constrains(
+        "alias_name",
+        "field_id",
+        "field_id.name",
+    )
+    def _check_field_name_alias_name(self):
+        for rec in self:
+            if rec.alias_name == rec.field_id.name:
+                raise ValidationError(
+                    _("Alias Name should be different from its field name!")
+                )
+
+    @api.constrains("field_id", "api_path_id")
+    def _check_field_duplicate_if_api_path_is_null(self):
+        for rec in self:
+            if rec.api_path_id:
+                continue
+            to_check = self.search(
+                [
+                    ("field_id", "=", rec.field_id.id),
+                    ("api_path_id", "=", False),
+                    ("id", "!=", rec.id),
+                ],
+                limit=1,
+            )
+            if to_check:
+                raise ValidationError(
+                    _("There is another global alias for this field!")
+                )
+
+    def _inverse_global_alias(self):
+        for rec in self:
+            if rec.global_alias:
+                rec.api_path_id = False

--- a/spp_api/models/spp_api_fields.py
+++ b/spp_api/models/spp_api_fields.py
@@ -44,5 +44,5 @@ class SPPAPIField(models.Model):
 
     def _get_field_name(self):
         self.ensure_one()
-        field_alias = self.path_id._get_field_name_alias(self)
+        field_alias = self.path_id._get_field_name_alias(self.field_id)
         return field_alias.alias_name if field_alias else self.field_name

--- a/spp_api/models/spp_api_fields.py
+++ b/spp_api/models/spp_api_fields.py
@@ -41,3 +41,8 @@ class SPPAPIField(models.Model):
         return self.field_id.with_context(
             default_api_path_id=self.path_id.id
         ).create_api_field_name_alias()
+
+    def _get_field_name(self):
+        self.ensure_one()
+        field_alias = self.path_id._get_field_name_alias(self)
+        return field_alias.alias_name if field_alias else self.field_name

--- a/spp_api/models/spp_api_fields.py
+++ b/spp_api/models/spp_api_fields.py
@@ -35,3 +35,9 @@ class SPPAPIField(models.Model):
     def on_required_change(self):
         if self.default_value:
             self.required = False
+
+    def create_api_field_name_alias(self):
+        self.ensure_one()
+        return self.field_id.with_context(
+            default_api_path_id=self.path_id.id
+        ).create_api_field_name_alias()

--- a/spp_api/models/spp_api_path.py
+++ b/spp_api/models/spp_api_path.py
@@ -915,10 +915,20 @@ class SPPAPIPath(models.Model):
             "type": "ir.actions.act_window",
             "name": _("Field Name Alias"),
             "res_model": "spp_api.field.alias",
-            "domain": ["|", ("api_path_id", "=", self.id), ("api_path_id", "=", False)],
+            "domain": self._get_related_field_alias_domain(),
             "view_mode": "tree,form",
             "context": {"default_api_path_id": self.id, "scoped_alias": True},
         }
+
+    def _get_related_field_alias_domain(self):
+        self.ensure_one()
+        return [
+            "|",
+            ("api_path_id", "=", self.id),
+            "&",
+            ("api_path_id", "=", False),
+            ("model_id", "=", self.model_id.id),
+        ]
 
     def _get_field_name_alias(self, field):
         self.ensure_one()

--- a/spp_api/models/spp_api_path.py
+++ b/spp_api/models/spp_api_path.py
@@ -917,7 +917,11 @@ class SPPAPIPath(models.Model):
             "res_model": "spp_api.field.alias",
             "domain": self._get_related_field_alias_domain(),
             "view_mode": "tree,form",
-            "context": {"default_api_path_id": self.id, "scoped_alias": True},
+            "context": {
+                "default_api_path_id": self.id,
+                "scoped_alias": True,
+                "create": False,
+            },
         }
 
     def _get_related_field_alias_domain(self):

--- a/spp_api/models/spp_api_path.py
+++ b/spp_api/models/spp_api_path.py
@@ -960,3 +960,19 @@ class SPPAPIPath(models.Model):
                 )
             )
         return field_alias
+
+    def _get_response_treatment(self, response_data):
+        if isinstance(response_data, dict):
+            response_data = [response_data]
+        self.ensure_one()
+        field_aliases = (
+            self.env["spp_api.field.alias"]
+            .sudo()
+            .search(self._get_related_field_alias_domain())
+        )
+        for element in response_data:
+            for field_alias in field_aliases:
+                if field_alias.field_id.name not in element.keys():
+                    continue
+                element[field_alias.alias_name] = element.pop(field_alias.field_id.name)
+        return response_data

--- a/spp_api/security/ir.model.access.csv
+++ b/spp_api/security/ir.model.access.csv
@@ -3,10 +3,11 @@ user_access_spp_api_log,access_spp_api_log,model_spp_api_log,spp_api.group_user,
 user_access_spp_api_namespace,access_spp_api_namespace,model_spp_api_namespace,spp_api.group_user,1,0,0,0
 user_access_spp_api_path,access_spp_api_path,model_spp_api_path,spp_api.group_user,1,0,0,0
 user_access_spp_api_field,access_spp_api_field,model_spp_api_field,spp_api.group_user,1,0,0,0
+access_spp_api_field_alias_group_user,spp.api.field.alias.group.user,model_spp_api_field_alias,spp_api.group_user,1,0,0,0
 user_access_spp_api_function_parameter,access_spp_api_function_parameter,model_spp_api_function_parameter,spp_api.group_user,1,0,0,0
 manager_access_spp_api_log,access_spp_api_log,model_spp_api_log,spp_api.group_manager,1,1,1,1
 manager_access_spp_api_namespace,access_spp_api_namespace,model_spp_api_namespace,spp_api.group_manager,1,1,1,1
 manager_access_spp_api_path,access_spp_api_path,model_spp_api_path,spp_api.group_manager,1,1,1,1
 manager_access_spp_api_field,access_spp_api_field,model_spp_api_field,spp_api.group_manager,1,1,1,1
 manager_access_spp_api_function_parameter,access_spp_api_function_parameter,model_spp_api_function_parameter,spp_api.group_manager,1,1,1,1
-,,,
+access_spp_api_field_alias_group_manager,spp.api.field.alias.group.manager,model_spp_api_field_alias,spp_api.group_manager,1,1,1,1

--- a/spp_api/views/openapi_view.xml
+++ b/spp_api/views/openapi_view.xml
@@ -58,6 +58,7 @@
         <field name="type">tree</field>
         <field name="arch" type="xml">
             <tree string="Paths" decoration-muted="not active">
+                <button icon="fa-external-link" name="open_self_form" type="object" class="btn btn-success" />
                 <field name="namespace_id" />
                 <field name="name" />
                 <field name="active" widget="boolean_toggle" />
@@ -74,6 +75,16 @@
         <field name="arch" type="xml">
             <form string="Path">
                 <sheet>
+                    <div class="oe_button_box" name="button_box">
+                        <button
+                            name="action_open_field_alias"
+                            type="object"
+                            class="oe_stat_button"
+                            icon="fa-cog"
+                        >
+                            <span>Field Aliases</span>
+                        </button>
+                    </div>
                     <widget
                         name="web_ribbon"
                         title="Inactive"
@@ -117,12 +128,20 @@
                             options="{'model': 'model', 'in_dialog': True}"
                             placeholder="Add domain to filter result, example: [('name', '=', 'Test')]"
                         />
-                        <field
-                            name="field_ids"
-                            widget="many2many_tags"
-                            attrs="{'required': [('method', '=', 'get')]}"
-                            options="{'no_create': True}"
-                        />
+                        <field name="field_ids" options="{'no_create': True}">
+                            <tree>
+                                <field name="name" />
+                                <field name="field_description" />
+                                <field name="ttype" />
+                                <button
+                                    string="Field Alias"
+                                    name="create_api_field_name_alias"
+                                    context="{'default_api_path_id': parent.id}"
+                                    type="object"
+                                    class="btn btn-small btn-success"
+                                />
+                            </tree>
+                        </field>
                     </group>
                     <field name="warning_required" invisible="1" />
                     <group
@@ -155,6 +174,12 @@
                                 <field
                                     name="required"
                                     attrs="{'readonly': [('default_value', 'not in', ['', False])]}"
+                                />
+                                <button
+                                    string="Field Alias"
+                                    name="create_api_field_name_alias"
+                                    type="object"
+                                    class="btn btn-small btn-success"
                                 />
                             </tree>
                         </field>

--- a/spp_api/views/spp_api_field_alias_views.xml
+++ b/spp_api/views/spp_api_field_alias_views.xml
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="spp_api_field_alias_view_search" model="ir.ui.view">
+        <field name="name">spp_api.field.alias.view.search</field>
+        <field name="model">spp_api.field.alias</field>
+        <field name="arch" type="xml">
+            <search string="Field Name Alias">
+                <field name="alias_name" />
+                <field name="field_id" />
+                <field name="api_path_id" />
+                <filter
+                    name="fltr_global_alias"
+                    string="Global Alias"
+                    domain="[('global_alias', '=', True)]"
+                />
+                <filter
+                    name="fltr_non_global_alias"
+                    string="Scoped Alias"
+                    domain="[('global_alias', '=', False)]"
+                />
+                <group expand="0" string="Group By">
+                    <filter name="grp_field_id" string="Field" context="{'group_by': 'field_id'}" />
+                    <filter name="grp_api_path_id" string="Api Path" context="{'group_by': 'api_path_id'}" />
+                </group>
+            </search>
+        </field>
+    </record>
+
+    <record id="spp_api_field_alias_view_tree" model="ir.ui.view">
+        <field name="name">spp_api.field.alias.view.tree</field>
+        <field name="model">spp_api.field.alias</field>
+        <field name="arch" type="xml">
+            <tree string="Field Name Alias">
+                <field name="alias_name" />
+                <field name="field_id" />
+                <field name="api_path_id" />
+                <field name="global_alias" />
+            </tree>
+        </field>
+    </record>
+
+    <record id="spp_api_field_alias_view_form" model="ir.ui.view">
+        <field name="name">spp_api.field.alias.view.form</field>
+        <field name="model">spp_api.field.alias</field>
+        <field name="arch" type="xml">
+            <form string="Field Name Alias">
+                <sheet>
+                    <group>
+                        <group>
+                            <field name="field_id" readonly="context.get('scoped_alias')" />
+                        </group>
+                    </group>
+                    <group>
+                        <group>
+                            <field name="alias_name" />
+                            <field name="global_alias" invisible="context.get('scoped_alias')" />
+                        </group>
+                        <group attrs="{'invisible': [('global_alias', '=', True)]}">
+                            <field
+                                name="api_path_id"
+                                readonly="context.get('scoped_alias')"
+                                attrs="{'required': [('global_alias', '=', False)]}"
+                            />
+                        </group>
+                    </group>
+                </sheet>
+            </form>
+        </field>
+    </record>
+
+    <record id="spp_api_field_alias_action" model="ir.actions.act_window">
+        <field name="name">Field Alias</field>
+        <field name="res_model">spp_api.field.alias</field>
+        <field name="view_mode">tree,form</field>
+    </record>
+
+    <menuitem id="spp_api_config_menu" name="Settings" parent="spp_api.main_openapi_menu" sequence="10000" />
+
+    <menuitem
+        id="spp_api_field_alias_menu"
+        name="Field Alias"
+        action="spp_api_field_alias_action"
+        groups="group_manager"
+        parent="spp_api_config_menu"
+        sequence="10"
+    />
+
+</odoo>


### PR DESCRIPTION
## What this done?

- [x] From each field in the API, we need to add a button to create `alias field name` [new model] for that specific API Path only.
- [x] Each `alias field name` can be accessible via the button box in API Path. [for reviewing & changing if needed]
- [x] All the return response & docs route should be changed accordingly as well.
- [x] API Path will need a new action for accessing its full form [new changes will be seen there]
- [x] Fields need a better view than the `many2may_tags` to show the button on request [2].