### PR TITLE
[UPD] add program_id to service point

### DIFF
--- a/spp_api/tests/__init__.py
+++ b/spp_api/tests/__init__.py
@@ -1,5 +1,8 @@
 from . import test_json_spec
 from . import test_api
-
+from . import test_ir_model_fields
 from . import test_res_users
+from . import test_spp_api_field_alias
+from . import test_spp_api_field_path
+from . import test_spp_api_fields
 from . import test_spp_api_log

--- a/spp_api/tests/test_ir_model_fields.py
+++ b/spp_api/tests/test_ir_model_fields.py
@@ -1,0 +1,50 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+
+
+class TestIrModelFields(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.test_path = self.env["spp_api.path"].create(
+            {
+                "name": "res.partner",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "namespace_id": self.env.ref("spp_api.namespace_demo").id,
+                "description": "GET res.partner",
+                "method": "get",
+                "field_ids": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.field_res_partner__name").id,
+                            self.env.ref("base.field_res_partner__write_date").id,
+                        ],
+                    )
+                ],
+            }
+        )
+        self.test_field_alias = self.env["spp_api.field.alias"].create(
+            {
+                "field_id": self.env.ref("base.field_res_partner__write_date").id,
+                "alias_name": "last_updated",
+                "api_path_id": self.test_path.id,
+            }
+        )
+
+    def test_01_create_api_field_name_alias(self):
+        test_field_name = self.env.ref("base.field_res_partner__name")
+        test_field_write_date = self.env.ref("base.field_res_partner__write_date")
+        with self.assertRaisesRegex(ValidationError, "API path is not specify!"):
+            test_field_name.create_api_field_name_alias()
+        res = test_field_name.with_context(
+            default_api_path_id=self.test_path.id
+        ).create_api_field_name_alias()
+        self.assertTrue(type(res) == dict, "Return values should be an action!")
+        self.assertFalse(bool(res.get("res_id")), "Name doesn't have its field alias!")
+        res = test_field_write_date.with_context(
+            default_api_path_id=self.test_path.id
+        ).create_api_field_name_alias()
+        self.assertTrue(
+            bool(res.get("res_id")), "Write date has field alias, it should be shown!"
+        )

--- a/spp_api/tests/test_spp_api_field_alias.py
+++ b/spp_api/tests/test_spp_api_field_alias.py
@@ -1,0 +1,62 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+from odoo.tools import mute_logger
+
+
+class TestSppApiFieldAlias(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.test_path = self.env["spp_api.path"].create(
+            {
+                "name": "res.partner",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "namespace_id": self.env.ref("spp_api.namespace_demo").id,
+                "description": "GET res.partner",
+                "method": "get",
+                "field_ids": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.field_res_partner__name").id,
+                            self.env.ref("base.field_res_partner__write_date").id,
+                        ],
+                    )
+                ],
+            }
+        )
+        self.test_field_alias = self.env["spp_api.field.alias"].create(
+            {
+                "field_id": self.env.ref("base.field_res_partner__write_date").id,
+                "alias_name": "last_updated",
+                "api_path_id": self.test_path.id,
+            }
+        )
+
+    def test_01_name_get(self):
+        res = self.test_field_alias.name_get()[0][1]
+        self.assertEqual(res, "last_updated - write_date")
+
+    @mute_logger("py.warnings")
+    def test_02_check_field_name_alias_name(self):
+        with self.assertRaisesRegex(
+            ValidationError, "Alias Name should be different from its field name!"
+        ):
+            self.test_field_alias.write({"alias_name": "write_date"})
+
+    def test_03_inverse_global_alias(self):
+        self.test_field_alias.write({"global_alias": True})
+        self.assertFalse(bool(self.test_field_alias.api_path_id))
+
+    def test_04_check_field_duplicate_if_api_path_is_null(self):
+        self.test_field_alias.write({"global_alias": True})
+        with self.assertRaisesRegex(
+            ValidationError, "There is another global alias for this field!"
+        ):
+            self.env["spp_api.field.alias"].create(
+                {
+                    "field_id": self.env.ref("base.field_res_partner__write_date").id,
+                    "alias_name": "last_updated",
+                    "global_alias": True,
+                }
+            )

--- a/spp_api/tests/test_spp_api_field_path.py
+++ b/spp_api/tests/test_spp_api_field_path.py
@@ -1,0 +1,125 @@
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+
+
+class TestSppApiFieldPath(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.test_get_path = self.env["spp_api.path"].create(
+            {
+                "name": "res.partner",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "namespace_id": self.env.ref("spp_api.namespace_demo").id,
+                "description": "GET res.partner",
+                "method": "get",
+                "field_ids": [
+                    (
+                        6,
+                        0,
+                        [
+                            self.env.ref("base.field_res_partner__name").id,
+                            self.env.ref("base.field_res_partner__write_date").id,
+                        ],
+                    )
+                ],
+            }
+        )
+        self.test_get_field_alias = self.env["spp_api.field.alias"].create(
+            {
+                "field_id": self.env.ref("base.field_res_partner__write_date").id,
+                "alias_name": "last_updated",
+                "api_path_id": self.test_get_path.id,
+            }
+        )
+        self.test_post_path = self.env["spp_api.path"].create(
+            {
+                "name": "res.partner",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "namespace_id": self.env.ref("spp_api.namespace_demo").id,
+                "description": "POST res.partner",
+                "method": "post",
+            }
+        )
+        self.test_api_field = self.env["spp_api.field"].create(
+            {
+                "field_id": self.env.ref("base.field_res_partner__name").id,
+                "required": True,
+                "path_id": self.test_post_path.id,
+            }
+        )
+        self.test_post_field_alias = self.env["spp_api.field.alias"].create(
+            {
+                "field_id": self.env.ref("base.field_res_partner__name").id,
+                "alias_name": "fullname",
+                "api_path_id": self.test_post_path.id,
+            }
+        )
+
+    def test_01_check_field_get_method(self):
+        with self.assertRaisesRegex(
+            ValidationError, "API need a specific fields list!"
+        ):
+            self.test_get_path.write({"field_ids": [(5, 0, 0)]})
+
+    def test_02_open_self_form(self):
+        res = self.test_get_path.open_self_form()
+        self.assertEqual(type(res), dict, "Return vals should be an action!")
+        self.assertEqual(
+            res["res_model"], "spp_api.path", "Return vals should be an action!"
+        )
+        self.assertEqual(
+            res["res_id"], self.test_get_path.id, "Return vals should be an action!"
+        )
+        self.assertEqual(
+            res["type"], "ir.actions.act_window", "Return vals should be an action!"
+        )
+
+    def test_03_action_open_field_alias(self):
+        res = self.test_get_path.action_open_field_alias()
+        self.assertEqual(type(res), dict, "Return vals should be an action!")
+        self.assertEqual(
+            res["res_model"], "spp_api.field.alias", "Return vals should be an action!"
+        )
+        self.assertEqual(
+            res["context"].get("default_api_path_id"),
+            self.test_get_path.id,
+            "Return vals should be an action!",
+        )
+        self.assertEqual(
+            res["type"], "ir.actions.act_window", "Return vals should be an action!"
+        )
+
+    def test_04_fields_alias_treatment(self):
+        res = self.test_post_path._fields_alias_treatment(
+            {"fullname": "Name 1", "age": 11}
+        )
+        self.assertIn("name", res.keys(), "Post values should be treated correctly!")
+        self.assertNotIn(
+            "fullname", res.keys(), "Post values should be treated correctly!"
+        )
+        self.assertEqual(
+            res["name"], "Name 1", "Post values should be treated correctly!"
+        )
+
+    def test_05_get_response_treatment(self):
+        res = self.test_get_path._get_response_treatment(
+            {"name": "Name", "write_date": "2023-11-13 13:12:00"}
+        )
+        self.assertEqual(type(res), list, "Get values should be treated correctly!")
+        for element in res:
+            self.assertEqual(
+                type(element), dict, "Get values should be treated correctly!"
+            )
+            self.assertIn(
+                "last_updated",
+                element.keys(),
+                "Get values should be treated correctly!",
+            )
+            self.assertNotIn(
+                "write_date", element.keys(), "Get values should be treated correctly!"
+            )
+            self.assertEqual(
+                element["last_updated"],
+                "2023-11-13 13:12:00",
+                "Get values should be treated correctly!",
+            )

--- a/spp_api/tests/test_spp_api_fields.py
+++ b/spp_api/tests/test_spp_api_fields.py
@@ -1,0 +1,40 @@
+from odoo.tests import TransactionCase
+
+
+class TestSppApiFields(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.test_path = self.env["spp_api.path"].create(
+            {
+                "name": "res.partner",
+                "model_id": self.env.ref("base.model_res_partner").id,
+                "namespace_id": self.env.ref("spp_api.namespace_demo").id,
+                "description": "POST res.partner",
+                "method": "post",
+            }
+        )
+        self.test_api_field = self.env["spp_api.field"].create(
+            {
+                "field_id": self.env.ref("base.field_res_partner__name").id,
+                "required": True,
+                "path_id": self.test_path.id,
+            }
+        )
+        self.test_field_alias = self.env["spp_api.field.alias"].create(
+            {
+                "field_id": self.env.ref("base.field_res_partner__name").id,
+                "alias_name": "fullname",
+                "api_path_id": self.test_path.id,
+            }
+        )
+
+    def test_01_create_api_field_name_alias(self):
+        res = self.test_api_field.create_api_field_name_alias()
+        self.assertTrue(type(res) == dict, "Return vals should be an action!")
+
+    def test_02_get_field_name(self):
+        res = self.test_api_field._get_field_name()
+        self.assertEqual(res, "fullname", "Field should return field name alias!")
+        self.test_field_alias.unlink()
+        res = self.test_api_field._get_field_name()
+        self.assertEqual(res, "name", "Field should return field name!")

--- a/spp_api_records/__manifest__.py
+++ b/spp_api_records/__manifest__.py
@@ -22,10 +22,12 @@
         "contacts",
         "g2p_registry_base",
         "spp_area",
+        "spp_programs_sp",
     ],
     "data": [
         "data/spp_api_namespace_data.xml",
         "data/spp_api_path_data.xml",
+        "views/spp_service_point_views.xml",
         "views/uom_category_views.xml",
         "data/spp_api_field_data.xml",
         "data/spp_api_field_alias_data.xml",

--- a/spp_api_records/models/__init__.py
+++ b/spp_api_records/models/__init__.py
@@ -1,3 +1,4 @@
+from . import spp_service_point
 from . import uom_uom
 from . import g2p_entitlements
 from . import g2p_program

--- a/spp_api_records/models/spp_service_point.py
+++ b/spp_api_records/models/spp_service_point.py
@@ -1,0 +1,79 @@
+from odoo import _, fields, models
+from odoo.exceptions import ValidationError
+
+
+class SppServicePoint(models.Model):
+    _inherit = "spp.service.point"
+
+    program_id = fields.Many2many(
+        comodel_name="g2p.program",
+        string="Program",
+        compute="_compute_program_id",
+        search="_search_program_id",
+        store=False,
+    )
+
+    def _compute_program_id(self):
+        SQL_QUERY = """
+        SELECT
+            gesprel.spp_service_point_id AS sp_id,
+            gc.program_id AS prg_id
+        FROM
+            g2p_entitlement ge
+            JOIN g2p_entitlement_spp_service_point_rel gesprel ON ge.id = gesprel.g2p_entitlement_id
+            JOIN g2p_cycle gc ON ge.cycle_id = gc.id
+        WHERE
+            gesprel.spp_service_point_id IN %(self_ids)s
+
+        UNION ALL
+
+        SELECT
+            geisprel.spp_service_point_id AS sp_id,
+            gc.program_id AS prg_id
+        FROM
+            g2p_entitlement_inkind gei
+            JOIN g2p_entitlement_inkind_spp_service_point_rel geisprel ON gei.id = geisprel.g2p_entitlement_inkind_id
+            JOIN g2p_cycle gc ON gei.cycle_id = gc.id
+        WHERE
+            geisprel.spp_service_point_id IN %(self_ids)s
+        """
+        self.env.cr.execute(SQL_QUERY, {"self_ids": tuple(self.ids)})
+        res = self.env.cr.dictfetchall()
+        for rec in self:
+            rec_program_ids = []
+            for item in res:
+                if item["sp_id"] != rec.id:
+                    continue
+                rec_program_ids.append(item["prg_id"])
+            rec.program_id = [(6, 0, rec_program_ids)]
+
+    def _search_program_id(self, operator, value):
+        if operator != "=":
+            raise ValidationError(_("Operator is not supported!"))
+        SQL_QUERY = """
+        SELECT
+            gesprel.spp_service_point_id AS sp_id,
+            gc.program_id AS prg_id
+        FROM
+            g2p_entitlement ge
+            JOIN g2p_entitlement_spp_service_point_rel gesprel ON ge.id = gesprel.g2p_entitlement_id
+            JOIN g2p_cycle gc ON ge.cycle_id = gc.id
+        WHERE
+            gc.program_id = %(program_id)s
+
+        UNION ALL
+
+        SELECT
+            geisprel.spp_service_point_id AS sp_id,
+            gc.program_id AS prg_id
+        FROM
+            g2p_entitlement_inkind gei
+            JOIN g2p_entitlement_inkind_spp_service_point_rel geisprel ON gei.id = geisprel.g2p_entitlement_inkind_id
+            JOIN g2p_cycle gc ON gei.cycle_id = gc.id
+        WHERE
+            gc.program_id = %(program_id)s
+        """
+        self.env.cr.execute(SQL_QUERY, {"program_id": value})
+        res = self.env.cr.dictfetchall()
+        service_point_ids = [item["sp_id"] for item in res]
+        return [("id", "in", service_point_ids)]

--- a/spp_api_records/tests/__init__.py
+++ b/spp_api_records/tests/__init__.py
@@ -1,0 +1,1 @@
+from . import test_spp_service_point

--- a/spp_api_records/tests/__init__.py
+++ b/spp_api_records/tests/__init__.py
@@ -1,1 +1,2 @@
+from . import test_g2p_entitlement
 from . import test_spp_service_point

--- a/spp_api_records/tests/test_g2p_entitlement.py
+++ b/spp_api_records/tests/test_g2p_entitlement.py
@@ -1,0 +1,60 @@
+from odoo import fields
+from odoo.tests import TransactionCase
+
+
+class TestG2pEntitlements(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.test_group = self.env["res.partner"].create(
+            {
+                "name": "group 1",
+                "is_registrant": True,
+                "is_group": True,
+            }
+        )
+        self.test_program_1 = self.env["g2p.program"].create(
+            {
+                "name": "program 1",
+            }
+        )
+        self.test_cycle_1 = self.env["g2p.cycle"].create(
+            {
+                "name": "cycle 1",
+                "program_id": self.test_program_1.id,
+                "start_date": fields.Date.today(),
+                "end_date": fields.Date.add(fields.Date.today(), days=30),
+            }
+        )
+        self.test_entitlement = self.env["g2p.entitlement"].create(
+            {
+                "cycle_id": self.test_cycle_1.id,
+                "partner_id": self.test_group.id,
+                "initial_amount": 50_000,
+            }
+        )
+        self.test_entitlement_inkind = self.env["g2p.entitlement.inkind"].create(
+            {
+                "cycle_id": self.test_cycle_1.id,
+                "partner_id": self.test_group.id,
+            }
+        )
+
+    def test_01_compute_partner_type(self):
+        self.assertEqual(self.test_entitlement.partner_type, "group")
+        self.test_group.is_group = False
+        self.test_entitlement._compute_partner_type()
+        self.assertEqual(self.test_entitlement.partner_type, "individual")
+
+    def test_02_compute_type(self):
+        self.assertEqual(self.test_entitlement.type, "inkind")
+        self.test_entitlement.is_cash_entitlement = True
+        self.assertEqual(self.test_entitlement.type, "cash")
+
+    def test_01_compute_partner_type_inkind(self):
+        self.assertEqual(self.test_entitlement_inkind.partner_type, "group")
+        self.test_group.is_group = False
+        self.test_entitlement_inkind._compute_partner_type()
+        self.assertEqual(self.test_entitlement_inkind.partner_type, "individual")
+
+    def test_02_compute_type_inkind(self):
+        self.assertEqual(self.test_entitlement_inkind.type, "inkind")

--- a/spp_api_records/tests/test_spp_service_point.py
+++ b/spp_api_records/tests/test_spp_service_point.py
@@ -1,0 +1,188 @@
+from odoo import fields
+from odoo.exceptions import ValidationError
+from odoo.tests import TransactionCase
+
+
+class TestSppServicePoint(TransactionCase):
+    def setUp(self):
+        super().setUp()
+        self.test_service_point_1 = self.env["spp.service.point"].create(
+            {
+                "name": "service point 1",
+            }
+        )
+        self.test_service_point_2 = self.env["spp.service.point"].create(
+            {
+                "name": "service point 2",
+            }
+        )
+        self.test_service_point_3 = self.env["spp.service.point"].create(
+            {
+                "name": "service point 3",
+            }
+        )
+        self.test_service_point_4 = self.env["spp.service.point"].create(
+            {
+                "name": "service point 4",
+            }
+        )
+        self.test_group = self.env["res.partner"].create(
+            {
+                "name": "group 1",
+                "is_registrant": True,
+                "is_group": True,
+            }
+        )
+        self.test_program_1 = self.env["g2p.program"].create(
+            {
+                "name": "program 1",
+            }
+        )
+        self.test_program_2 = self.env["g2p.program"].create(
+            {
+                "name": "program 2",
+            }
+        )
+        self.test_cycle_1 = self.env["g2p.cycle"].create(
+            {
+                "name": "cycle 1",
+                "program_id": self.test_program_1.id,
+                "start_date": fields.Date.today(),
+                "end_date": fields.Date.add(fields.Date.today(), days=30),
+            }
+        )
+        self.test_cycle_2 = self.env["g2p.cycle"].create(
+            {
+                "name": "cycle 2",
+                "program_id": self.test_program_2.id,
+                "start_date": fields.Date.today(),
+                "end_date": fields.Date.add(fields.Date.today(), days=30),
+            }
+        )
+        self.env["g2p.entitlement"].create(
+            [
+                {
+                    "cycle_id": self.test_cycle_1.id,
+                    "partner_id": self.test_group.id,
+                    "initial_amount": 50_000,
+                    "service_point_ids": [
+                        (
+                            6,
+                            0,
+                            [
+                                self.test_service_point_1.id,
+                                self.test_service_point_2.id,
+                            ],
+                        )
+                    ],
+                },
+                {
+                    "cycle_id": self.test_cycle_2.id,
+                    "partner_id": self.test_group.id,
+                    "initial_amount": 50_000,
+                    "service_point_ids": [
+                        (
+                            6,
+                            0,
+                            [
+                                self.test_service_point_1.id,
+                                self.test_service_point_3.id,
+                            ],
+                        )
+                    ],
+                },
+            ]
+        )
+
+    def test_01_compute_program_id(self):
+        service_point = (
+            self.test_service_point_1
+            | self.test_service_point_2
+            | self.test_service_point_3
+            | self.test_service_point_4
+        )
+        service_point._compute_program_id()
+        self.assertIn(
+            self.test_program_1,
+            self.test_service_point_1.program_id,
+            "Program 1 should be linked to service point 1!",
+        )
+        self.assertIn(
+            self.test_program_1,
+            self.test_service_point_2.program_id,
+            "Program 1 should be linked to service point 2!",
+        )
+        self.assertIn(
+            self.test_program_2,
+            self.test_service_point_1.program_id,
+            "Program 2 should be linked to service point 1!",
+        )
+        self.assertIn(
+            self.test_program_2,
+            self.test_service_point_3.program_id,
+            "Program 2 should be linked to service point 3!",
+        )
+        self.assertNotIn(
+            self.test_program_1,
+            self.test_service_point_3.program_id,
+            "Program 1 should not be linked to service point 3!",
+        )
+        self.assertNotIn(
+            self.test_program_2,
+            self.test_service_point_2.program_id,
+            "Program 2 should not be linked to service point 2!",
+        )
+        self.assertFalse(
+            bool(self.test_service_point_4.program_id.ids),
+            "Service point 4 should not be linked to any program!",
+        )
+
+    def test_02_search_program_id(self):
+        with self.assertRaisesRegex(ValidationError, "Operator is not supported!"):
+            self.env["spp.service.point"].search([("program_id", "in", [1, 2])])
+        res = self.env["spp.service.point"].search(
+            [("program_id", "=", self.test_program_1.id)]
+        )
+        self.assertIn(
+            self.test_service_point_1,
+            res,
+            "Service point 1 should be in search result when searching for program_id = program_1.id!",
+        )
+        self.assertIn(
+            self.test_service_point_2,
+            res,
+            "Service point 2 should be in search result when searching for program_id = program_1.id!",
+        )
+        self.assertNotIn(
+            self.test_service_point_3,
+            res,
+            "Service point 3 should not be in search result when searching for program_id = program_1.id!",
+        )
+        self.assertNotIn(
+            self.test_service_point_4,
+            res,
+            "Service point 4 should not be in search result when searching for program_id = program_1.id!",
+        )
+        res = self.env["spp.service.point"].search(
+            [("program_id", "=", self.test_program_2.id)]
+        )
+        self.assertIn(
+            self.test_service_point_1,
+            res,
+            "Service point 1 should be in search result when searching for program_id = program_2.id!",
+        )
+        self.assertIn(
+            self.test_service_point_3,
+            res,
+            "Service point 3 should be in search result when searching for program_id = program_2.id!",
+        )
+        self.assertNotIn(
+            self.test_service_point_2,
+            res,
+            "Service point 2 should not be in search result when searching for program_id = program_2.id!",
+        )
+        self.assertNotIn(
+            self.test_service_point_4,
+            res,
+            "Service point 4 should not be in search result when searching for program_id = program_1.id!",
+        )

--- a/spp_api_records/views/spp_service_point_views.xml
+++ b/spp_api_records/views/spp_service_point_views.xml
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<odoo>
+
+    <record id="view_service_points_tree_inherit_spp_api_records" model="ir.ui.view">
+        <field name="name">spp.service.point.view.list.inherit</field>
+        <field name="model">spp.service.point</field>
+        <field name="inherit_id" ref="spp_service_points.view_service_points_tree" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='area_id']" position="after">
+                <field name="program_id" widget="many2many_tags" />
+            </xpath>
+        </field>
+    </record>
+
+    <record id="view_service_points_form_inherit_spp_api_records" model="ir.ui.view">
+        <field name="name">spp.service.point.view.form.inherit</field>
+        <field name="model">spp.service.point</field>
+        <field name="inherit_id" ref="spp_service_points.view_service_points_form" />
+        <field name="arch" type="xml">
+            <xpath expr="//field[@name='country_id']" position="after">
+                <field name="program_id" widget="many2many_tags" />
+            </xpath>
+        </field>
+    </record>
+
+</odoo>

--- a/test-requirements.txt
+++ b/test-requirements.txt
@@ -1,9 +1,15 @@
 git+https://github.com/OpenG2P/openg2p-registry@15.0-develop#subdirectory=setup/g2p_registry_base
 git+https://github.com/OpenG2P/openg2p-registry@15.0-develop#subdirectory=setup/g2p_registry_group
-git+https://github.com/OpenG2P/openg2p-registry@15.0-develop#subdirectory=setup/g2p_registry_individual
+git+https://github.com/OpenG2P/openg2p-registry@15.0#subdirectory=setup/g2p_registry_individual
 git+https://github.com/OpenG2P/openg2p-registry@15.0-develop#subdirectory=setup/g2p_registry_membership
 git+https://github.com/OpenG2P/openg2p-registry@15.0-develop#subdirectory=setup/g2p_bank
 git+https://github.com/openspp/openspp-odoo-external-dependencies@15.0#subdirectory=setup/odoo_dynamic_dashboard
 git+https://github.com/OpenG2P/openg2p-program@15.0-develop#subdirectory=setup/g2p_programs
-git+https://github.com/OpenSPP/openspp-registry@15.0#subdirectory=setup/spp_service_points
+git+https://github.com/OpenSPP/openspp-program@15.1.1#subdirectory=setup/g2p_entitlement_cash
+git+https://github.com/OpenSPP/openspp-program@15.1.1#subdirectory=setup/spp_entitlement_in_kind
+git+https://github.com/OpenSPP/openspp-program@15.1.1#subdirectory=setup/spp_ent_trans
+git+https://github.com/OpenSPP/openspp-program@15.1.1#subdirectory=setup/spp_programs_sp
+git+https://github.com/OpenSPP/openspp-program@15.1.1#subdirectory=setup/spp_programs
+git+https://github.com/OpenSPP/openspp-registry@15.1.1#subdirectory=setup/spp_service_points
 git+https://github.com/OpenSPP/openspp-registry@15.0#subdirectory=setup/spp_area
+git+https://github.com/OpenSPP/openspp-registry@15.1.1#subdirectory=setup/spp_service_point_device


### PR DESCRIPTION
## WHAT THIS DOES?

- [x] add a field `program_id` [m2m, compute, non-stored, searchable] to service point [field name based on API requirements]
- [x] add custom function to compute & search program_id by executing sql query
- [x] adjust views [tree & form] for service point to display new field